### PR TITLE
milan: adding banner to the unsol notification helper

### DIFF
--- a/src/modules/module-avb/aecp-cmd-resp/aecp-aem-unsol-helper.h
+++ b/src/modules/module-avb/aecp-cmd-resp/aecp-aem-unsol-helper.h
@@ -1,3 +1,8 @@
+/* AVB support */
+/* SPDX-FileCopyrightText: Copyright © 2025 Kebag-Logic */
+/* SPDX-FileCopyrightText: Copyright © 2025 Alex Malki <alexandre.malki@kebag-logic.com> */
+/* SPDX-License-Identifier: MIT  */
+
 #ifndef __AECP_AEM_UNSOL_HELPER_H__
 #define __AECP_AEM_UNSOL_HELPER_H__
 


### PR DESCRIPTION
# Test (Gherkin)

## Given
2 controllers on different interfaces and the DUT in the same AVB network.

## When
Executing an action on the controller that generates unsolicited notification.

## Then 
Unsolicited notifications should reach out to the controller of interest.