### PR TITLE
#28: introducing get-as-path command

### DIFF
--- a/src/modules/meson.build
+++ b/src/modules/meson.build
@@ -755,6 +755,7 @@ if build_module_avb
       'module-avb/aecp-cmd-resp/aecp-aem-cmd-set-sampling-rate.c',
       'module-avb/aecp-cmd-resp/aecp-aem-cmd-set-stream-format.c',
       'module-avb/aecp-cmd-resp/aecp-aem-cmd-get-counters.c',
+      'module-avb/aecp-cmd-resp/aecp-aem-cmd-get-as-path.c',
       'module-avb/aecp-cmd-resp/aecp-aem-configuration.c',
       'module-avb/aecp-cmd-resp/aecp-aem-descriptors.c',
       'module-avb/aecp-cmd-resp/aecp-aem-get-avb-info.c',

--- a/src/modules/module-avb/aecp-aem-state.h
+++ b/src/modules/module-avb/aecp-aem-state.h
@@ -11,6 +11,7 @@
 #include <stddef.h>
 #include "internal.h"
 
+#include "gptp/gptp-defs.h"
 struct aem_state_var_info {
     /** The name of the var for debug */
     const char *var_name;
@@ -195,6 +196,15 @@ struct aecp_aem_counter_stream_output_state {
 };
 
 /**
+ * IEEE 1722.1-2021 Clause 7.4.41 GET_AS_PATHS
+ */
+struct aecp_aem_ptp_as_path_state {
+    struct aecp_aem_desc_base base_desc;
+    uint32_t path_count;
+    uint64_t path_trace[GPTP_AVB_HOPS_MAX];
+};
+
+/**
  * The aecp_aem_desc_base inherites from the base
  */
 enum aecp_aem_lock_types {
@@ -211,6 +221,7 @@ enum aecp_aem_lock_types {
     aecp_aem_counter_clock_domain,
     aecp_aem_counter_stream_input,
     aecp_aem_counter_stream_output,
+    aecp_aem_ptp_as_path,
     aecp_aem_unsol_notif,
 
     // aecp_aem_desc, This is only used to retrieve the value, dynamic change

--- a/src/modules/module-avb/aecp-aem.c
+++ b/src/modules/module-avb/aecp-aem.c
@@ -120,13 +120,6 @@ static int handle_stop_streaming(struct aecp *aecp, int64_t now, const void *m, 
 	return reply_not_implemented(aecp, m, len);
 }
 
-static int handle_get_as_path(struct aecp *aecp, int64_t now, const void *m,
-	 int len)
-{
-	pw_log_warn("%s: +%d: has to be implemented\n", __func__, __LINE__);
-	return reply_not_implemented(aecp, m, len);
-}
-
 static int handle_get_audio_map(struct aecp *aecp, int64_t now,
 	 const void *m, int len)
 {
@@ -322,7 +315,7 @@ static const struct cmd_info cmd_info[] = {
 						"get-avb-info", handle_cmd_get_avb_info),
 
 	AECP_AEM_HANDLE_CMD( AVB_AECP_AEM_CMD_GET_AS_PATH, true,
-						"get-as-path", handle_get_as_path),
+						"get-as-path", handle_cmd_get_avb_info),
 
 	AECP_AEM_HANDLE_CMD( AVB_AECP_AEM_CMD_GET_COUNTERS, true,
 						"get-counters", handle_cmd_get_counters),

--- a/src/modules/module-avb/aecp-aem.h
+++ b/src/modules/module-avb/aecp-aem.h
@@ -206,9 +206,12 @@ struct avb_packet_aecp_aem_get_avb_info {
 
 struct avb_packet_aecp_aem_get_as_path {
 	uint16_t descriptor_index;
-	uint16_t reserved;
+	union {
+		uint16_t reserved;
+		uint16_t count;
+	} __attribute__ ((__packed__));
+	uint64_t path_trace[0];
 } __attribute__ ((__packed__));
-
 
 
 struct avb_packet_aecp_aem_reboot {

--- a/src/modules/module-avb/aecp-cmd-resp/aecp-aem-cmd-get-as-path.c
+++ b/src/modules/module-avb/aecp-cmd-resp/aecp-aem-cmd-get-as-path.c
@@ -1,0 +1,66 @@
+
+/* AVB support */
+/* SPDX-FileCopyrightText: Copyright © 2025 Kebag-Logic */
+/* SPDX-FileCopyrightText: Copyright © 2025 Alexandre Malki <alexandre.malki@kebag-logic.com> */
+/* SPDX-License-Identifier: MIT */
+
+#include "../aecp-aem-descriptors.h"
+#include "../aecp-aem.h"
+#include "../aecp-aem-state.h"
+
+#include "aecp-aem-cmd-get-as-path.h"
+
+/* IEEE 1722.1-2021 Clause 7.4.41 GET_AS_PATHS */
+int aecp_aem_cmd_get_as_path(struct aecp *aecp, int64_t now, const void *m,
+    int len)
+{
+    uint8_t buf[2048];
+    const struct avb_ethernet_header *h = m;
+    const struct avb_packet_aecp_aem *p = SPA_PTROFF(h, sizeof(*h), void);
+    /* prepare the reply */
+    struct avb_ethernet_header *h_reply = (struct avb_ethernet_header*) buf;
+    struct avb_packet_aecp_aem *p_reply = SPA_PTROFF(h_reply, sizeof(*h_reply),
+        void);
+    struct avb_packet_aecp_aem_get_as_path *as_path;
+    struct descriptor *desc;
+    struct aecp_aem_ptp_as_path_state as_path_state = {0};
+    uint16_t ctrl_data_length;
+    uint16_t desc_index;
+    uint32_t as_path_lenght;
+    int rc = 0;
+
+    as_path = (struct avb_packet_aecp_aem_get_as_path *) p->payload;
+    ctrl_data_length = AVB_PACKET_GET_LENGTH(&p->aecp.hdr);
+    desc_index = ntohs(as_path->descriptor_index);
+    desc = server_find_descriptor(aecp->server, AVB_AEM_DESC_AVB_INTERFACE,
+        desc_index);
+
+    if (desc == NULL)
+        return reply_status(aecp, AVB_AECP_AEM_STATUS_NO_SUCH_DESCRIPTOR, m, len);
+
+    rc = aecp_aem_get_state_var(aecp, aecp->server->entity_id,
+        aecp_aem_ptp_as_path, desc_index, &as_path_state);
+
+    if (rc) {
+        pw_log_error("Could not get the AS path info\n");
+        spa_assert(0);
+        return -1;
+    }
+
+    /* Prepare the reply */
+    memset(buf, 0, sizeof(buf));
+    memcpy(buf, p, sizeof(*p));
+
+    for (int as_path_idx = 0; as_path_idx < (int)as_path_state.path_count; as_path_idx++) {
+        as_path_state.path_trace[as_path_idx] = htobe64(as_path_state.path_trace[as_path_idx]);
+    }
+
+    as_path_lenght = sizeof(as_path->path_trace[0]) * as_path_state.path_count;
+    memcpy(as_path->path_trace, &as_path_state, as_path_lenght);
+
+    AVB_PACKET_SET_LENGTH(&p_reply->aecp.hdr, ctrl_data_length +
+         sizeof(as_path->path_trace[0]) + as_path_state.path_count);
+
+    return reply_success(aecp, buf, len + sizeof(*as_path)+ as_path_lenght);
+}
+

--- a/src/modules/module-avb/aecp-cmd-resp/aecp-aem-cmd-get-as-path.h
+++ b/src/modules/module-avb/aecp-cmd-resp/aecp-aem-cmd-get-as-path.h
@@ -1,0 +1,13 @@
+/* AVB support */
+/* SPDX-FileCopyrightText: Copyright © 2025 Kebag-Logic */
+/* SPDX-FileCopyrightText: Copyright © 2025 Alex Malki <alexandre.malki@kebag-logic.com> */
+/* SPDX-License-Identifier: MIT  */
+
+#ifndef __AEC_AEM_CMD_GET_AS_PATH_H__
+#define __AEC_AEM_CMD_GET_AS_PATH_H__
+
+#include "aecp-aem-helpers.h"
+
+int aecp_aem_cmd_get_as_path(struct aecp *aecp, int64_t now, const void *m, int len);
+
+#endif // __AEC_AEM_CMD_GET_AS_PATH_H__

--- a/src/modules/module-avb/aecp-cmd-resp/aecp-aem-get-avb-info.c
+++ b/src/modules/module-avb/aecp-cmd-resp/aecp-aem-get-avb-info.c
@@ -1,5 +1,4 @@
 /* AVB support */
-/* SPDX-FileCopyrightText: Copyright © 2022 Wim Taymans */
 /* SPDX-FileCopyrightText: Copyright © 2025 Kebag-Logic */
 /* SPDX-FileCopyrightText: Copyright © 2025 Alex Malki <alexandre.malki@kebag-logic.com> */
 /* SPDX-License-Identifier: MIT  */

--- a/src/modules/module-avb/aecp-cmd-resp/aecp-aem-get-avb-info.h
+++ b/src/modules/module-avb/aecp-cmd-resp/aecp-aem-get-avb-info.h
@@ -1,5 +1,4 @@
 /* AVB support */
-/* SPDX-FileCopyrightText: Copyright © 2022 Wim Taymans */
 /* SPDX-FileCopyrightText: Copyright © 2025 Kebag-Logic */
 /* SPDX-FileCopyrightText: Copyright © 2025 Alex Malki <alexandre.malki@kebag-logic.com> */
 /* SPDX-License-Identifier: MIT  */

--- a/src/modules/module-avb/aecp-state-vars.h
+++ b/src/modules/module-avb/aecp-state-vars.h
@@ -56,6 +56,10 @@ static const struct aem_state_var_info milan_vars[] = {
     AECP_AEM_NEEDED_VAR(aecp_aem_counter_stream_output, "counter_stream_output",
          true, true, 1, sizeof(struct aecp_aem_counter_stream_output_state)),
 
+    /** One per AVB interface */
+    AECP_AEM_NEEDED_VAR(aecp_aem_ptp_as_path, "ptp-as-path", true, false, 1,
+        sizeof(struct aecp_aem_ptp_as_path_state)),
+
     AECP_AEM_NEEDED_VAR(aecp_aem_unsol_notif, "unsol_notif_recorded",false, true,
         16, sizeof(struct aecp_aem_unsol_notification_state)),
 };

--- a/src/modules/module-avb/gptp/gptp-defs.h
+++ b/src/modules/module-avb/gptp/gptp-defs.h
@@ -1,0 +1,16 @@
+/* AVB support */
+/* SPDX-FileCopyrightText: Copyright © 2025 Kebag-Logic */
+/* SPDX-FileCopyrightText: Copyright © 2025 Alex Malki <alexandre.malki@kebag-logic.com> */
+/* SPDX-License-Identifier: MIT  */
+
+#ifndef __GPTP_GPTP_DEFS_H__
+#define __GPTP_GPTP_DEFS_H__
+
+#define GPTP_TLV_TYPE_PATH_TRACE    0x0008
+
+
+/** AVB and Milan specific */
+
+#define GPTP_AVB_HOPS_MAX           14
+
+#endif // __GPTP_GPTP_DEFS_H__

--- a/src/modules/module-avb/gptp/tlv.h
+++ b/src/modules/module-avb/gptp/tlv.h
@@ -1,0 +1,24 @@
+/* AVB support */
+/* SPDX-FileCopyrightText: Copyright © 2025 Kebag-Logic */
+/* SPDX-FileCopyrightText: Copyright © 2025 Alex Malki <alexandre.malki@kebag-logic.com> */
+/* SPDX-License-Identifier: MIT  */
+
+#ifndef __GPTP_TLV_H__
+#define __GPTP_TLV_H__
+
+#include <stdint.h>
+#include "gptp-defs.h"
+
+/** @ see also {{@73#bkmrk-page-title}} */
+
+struct gptp_tlv_base {
+    uint16_t tlv_type;
+    uint16_t tlv_length;
+} __attribute__ ((__packed__));
+
+struct gptp_tlv_as_path {
+    struct gptp_tlv_base tlv;
+    uint64_t tlv_data[0];
+} __attribute__ ((__packed__));
+
+#endif // __GPTP_TLV_H__


### PR DESCRIPTION
For now, the test  can only check when as_path has no path_trace.

Waiting for ptp to set it up