### PR TITLE
71 acmp command handler ignores first bind rx command

### DIFF
--- a/src/modules/module-avb/acmp.c
+++ b/src/modules/module-avb/acmp.c
@@ -1280,7 +1280,6 @@ static int handle_connect_rx_command(struct acmp *acmp, uint64_t now,
 	int res;
 	uint16_t flags;
 
-
 	memcpy(buf, m, len);
 	pw_log_info("HANDLE: len: %i", len);
 	if (be64toh(p->listener_guid) != server->entity_id)
@@ -1316,8 +1315,6 @@ static int handle_connect_rx_command(struct acmp *acmp, uint64_t now,
 		 fsm->current_state = MILAN_ACMP_LISTENER_STA_UNBOUND;
 		 fsm->timeout = LONG_MAX;
 		 fsm->size = 0;
-
-		return 0;
 	}
 	pw_log_info("Proceeding with SM for listener 0x%lx.",
 					be64toh(p->listener_guid));

--- a/src/modules/module-avb/acmp.c
+++ b/src/modules/module-avb/acmp.c
@@ -1106,11 +1106,13 @@ static int handle_connect_tx_response(struct acmp *acmp,
 	(void) reply;
 	pw_log_info("HANDLE connect_tx_resp: len: %i", len);
 	const struct listener_fsm_cmd *fcmd;
-	struct fsm_state_listener *fsm = acmp_fsm_find(acmp, STREAM_LISTENER_FSM,
-		be64toh(resp->listener_guid));
+	struct fsm_state_listener *fsm;
 	int evt = AECP_MILAN_ACMP_EVT_RCV_PROBE_TX_RESP;
-
 	memcpy(buf, m, len);
+
+	fsm = acmp_fsm_find(acmp, STREAM_LISTENER_FSM,
+		be64toh(resp->listener_guid));
+
 	// At this state there should be a state machine from the rcv_bind_rx_cmd
 	if (!fsm) {
 		pw_log_info("connect_tx_resp: Creating new state machine for"


### PR DESCRIPTION
The changes are done to speed up the connection progress, instead of 6 seconds, it takes below 1 second now.